### PR TITLE
feat: support 3-pane diff mode and configs for window options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Support 3-pane diff mode and configs for window options
 
+### ⚙️ Miscellaneous Tasks
+
+- Change build script for v0.2.2-alpha.1
+
 ## [0.2.1] - 2024-08-08
 
 ### 🚀 Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [unreleased]
+
+### 🚀 Features
+
+- Support 3-pane diff mode and configs for window options
+
 ## [0.2.1] - 2024-08-08
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,14 +9,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "diffdirs_nvim"
 version = "0.2.1"
 dependencies = [
  "anyhow",
+ "derive_builder",
  "nvim-oxi",
+ "serde",
  "thiserror",
  "walkdir",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "libc"
@@ -140,6 +220,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "diffdirs_nvim"
-version = "0.2.1"
+version = "0.2.2-alpha.1"
 dependencies = [
  "anyhow",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ strip="debuginfo"
 
 [dependencies]
 anyhow = "1.0.86"
+derive_builder = "0.20.0"
 nvim-oxi = { version = "0.5", default-features=false }
+serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.63"
 walkdir = "2.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diffdirs_nvim"
-version = "0.2.1"
+version = "0.2.2-alpha.1"
 edition = "2021"
 
 [lib]

--- a/build.lua
+++ b/build.lua
@@ -14,7 +14,7 @@ local machine = string.lower(os_uname.machine)
 local artifact_name = "diffdirs-" .. os_name .. "-" .. machine .. "-" .. nvim_version .. ".so"
 
 local plugin_dir = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h")
-local download_url = "https://github.com/jayong93/diffdirs.nvim/releases/download/v0.2.1/" .. artifact_name
+local download_url = "https://github.com/jayong93/diffdirs.nvim/releases/download/v0.2.2-alpha.1/" .. artifact_name
 
 ---@param cmd string
 ---@param opts table

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,30 @@
+use nvim_oxi::{api::Window, Function};
+use serde::Deserialize;
+
+use crate::error::Error as DiffDirsError;
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    left_diff_opt_fn: Option<Function<Window, ()>>,
+    right_diff_opt_fn: Option<Function<Window, ()>>,
+}
+
+impl Config {
+    pub const fn new() -> Self {
+        Self { left_diff_opt_fn: None, right_diff_opt_fn: None }
+    }
+
+    pub fn set_left_diff_opt(&self, win: Window) -> Result<(), DiffDirsError> {
+        if let Some(f) = &self.left_diff_opt_fn {
+            f.call(win)?;
+        }
+        Ok(())
+    }
+
+    pub fn set_right_diff_opt(&self, win: Window) -> Result<(), DiffDirsError> {
+        if let Some(f) = &self.right_diff_opt_fn {
+            f.call(win)?;
+        }
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
-use error::Error as DiffDirsError;
+use derive_builder::Builder;
+use error::{BuilderError, Error as DiffDirsError};
+use serde::Deserialize;
 use std::{
     cell::RefCell,
     collections::{BTreeMap, BTreeSet},
@@ -11,17 +13,31 @@ use nvim_oxi::{
     api::{
         self,
         opts::{CmdOpts, CreateCommandOpts, SetKeymapOpts},
-        types::{CmdInfos, CommandArgs, CommandModifiers, CommandNArgs, Mode},
+        types::{CmdInfos, CommandArgs, CommandModifiers, CommandNArgs, Mode, SplitModifier},
         Buffer, StringOrFunction, TabPage,
     },
     print, Array, Dictionary, Function, Object,
 };
 
+mod config;
 mod error;
+
+#[derive(Debug)]
+enum DiffDirType {
+    Two(PathBuf, PathBuf),
+    Three(PathBuf, PathBuf, PathBuf),
+}
+
+impl Default for DiffDirType {
+    fn default() -> Self {
+        Self::Two(PathBuf::new(), PathBuf::new())
+    }
+}
 
 thread_local! {
     static DIFF_FILES: RefCell<BTreeMap<PathBuf, TabPage>> = const {RefCell::new(BTreeMap::new())};
-    static DIFF_DIRS: RefCell<(PathBuf, PathBuf)> = RefCell::new(Default::default());
+    static DIFF_DIRS: RefCell<DiffDirType> = RefCell::new(Default::default());
+    static CONFIG: RefCell<config::Config> = const {RefCell::new(config::Config::new())};
 }
 
 #[nvim_oxi::plugin]
@@ -36,7 +52,10 @@ fn diffdirs() -> nvim_oxi::Result<Dictionary> {
     ]))
 }
 
-fn setup(_: Object) -> Result<(), DiffDirsError> {
+fn setup(config: Object) -> Result<(), DiffDirsError> {
+    let de = nvim_oxi::serde::Deserializer::new(config);
+    let config = config::Config::deserialize(de)?;
+    CONFIG.replace(config);
     Ok(api::create_user_command(
         "DiffDirs",
         |args| -> Result<(), DiffDirsError> {
@@ -69,10 +88,31 @@ fn jump_to_diff_tab(path: String) -> Result<(), DiffDirsError> {
                 if tab.is_valid() {
                     Ok(api::set_current_tabpage(tab)?)
                 } else {
-                    DIFF_DIRS.with_borrow(|(left_dir, right_dir)| {
-                        show_diff_tab(&left_dir.join(&path), &right_dir.join(&path), false)?;
-                        *tab = api::get_current_tabpage();
-                        Ok(())
+                    DIFF_DIRS.with_borrow(|dirs| {
+                        CONFIG.with_borrow(|config| {
+                            match dirs {
+                                DiffDirType::Two(left_dir, right_dir) => {
+                                    DiffTabBuilder::default()
+                                        .left_file(&(left_dir.join(&path)))
+                                        .right_file(&(right_dir.join(&path)))
+                                        .config(config)
+                                        .build()?
+                                        .open(false)?;
+                                    *tab = api::get_current_tabpage();
+                                }
+                                DiffDirType::Three(left_dir, right_dir, output_dir) => {
+                                    DiffTabBuilder::default()
+                                        .left_file(&(left_dir.join(&path)))
+                                        .right_file(&(right_dir.join(&path)))
+                                        .output_file(output_dir.join(&path))
+                                        .config(config)
+                                        .build()?
+                                        .open(false)?;
+                                    *tab = api::get_current_tabpage();
+                                }
+                            };
+                            Ok(())
+                        })
                     })
                 }
             })
@@ -106,42 +146,24 @@ fn setup_keymap() -> Result<(), DiffDirsError> {
 
 fn show_diff(args: CommandArgs) -> Result<(), DiffDirsError> {
     let cmd_args = &args.fargs;
-    match cmd_args.as_slice() {
-        [left_dir, right_dir] => {
-            let left_dir = Path::new(left_dir);
-            let right_dir = Path::new(right_dir);
-            DIFF_DIRS.replace((left_dir.to_owned(), right_dir.to_owned()));
-            let files = make_file_set(left_dir, right_dir);
-
-            let first_tabpage = api::get_current_tabpage();
-            let mut is_first_cmd = true;
-            api::call_function::<_, usize>("setqflist", (Array::new(), 'r'))?;
-
-            let mut path_tab_map = BTreeMap::new();
-            for file in files {
-                let left_file = left_dir.join(&file);
-                let right_file = right_dir.join(&file);
-                show_diff_tab(&left_file, &right_file, is_first_cmd)?;
-                let right_buf = Buffer::current();
-                let mut qflist_entry = Dictionary::new();
-                qflist_entry.insert("bufnr", right_buf.handle());
-                qflist_entry.insert("filename", right_file.to_string_lossy());
-                qflist_entry.insert("text", file.to_string_lossy());
-                api::call_function::<_, usize>(
-                    "setqflist",
-                    (Array::from_iter([qflist_entry]), 'a'),
-                )?;
-                is_first_cmd = false;
-                path_tab_map.insert(file, api::get_current_tabpage());
-            }
-            api::set_current_tabpage(&first_tabpage)?;
-            DIFF_FILES.replace(path_tab_map);
-            Ok(())
-        }
+    CONFIG.with_borrow(|config| match cmd_args.as_slice() {
+        [left_dir, right_dir] => DiffContextBuilder::default()
+            .left_dir(Path::new(left_dir))
+            .right_dir(Path::new(right_dir))
+            .config(config)
+            .build()?
+            .open_tabs(),
+        [left_dir, right_dir, output_dir] => DiffContextBuilder::default()
+            .left_dir(Path::new(left_dir))
+            .right_dir(Path::new(right_dir))
+            .output_dir(Path::new(output_dir))
+            .config(config)
+            .build()?
+            .open_tabs(),
         _ => Err(DiffDirsError::other(
             "the number of arguments for 'DiffDirs' command wasn't 2",
         )),
-    }
+    })
 }
 
 fn collect_file_paths(dir: &Path) -> BTreeSet<PathBuf> {
@@ -178,25 +200,124 @@ fn make_file_set(left_dir: &Path, right_dir: &Path) -> BTreeSet<PathBuf> {
     file_set
 }
 
-fn show_diff_tab(left_file: &Path, right_file: &Path, is_first: bool) -> Result<(), DiffDirsError> {
-    let cmd_opt = CmdOpts::builder().output(false).build();
-    let new_tab_cmd_str = if is_first { "edit" } else { "tabedit" };
-    let new_tab_cmd = CmdInfos::builder()
-        .cmd(new_tab_cmd_str)
-        .args([left_file.to_string_lossy()])
-        .nextcmd("difft")
-        .build();
-    let mut command_mod = CommandModifiers::default();
-    command_mod.vertical = true;
-    let diff_tab_cmd = CmdInfos::builder()
-        .cmd("diffs")
-        .args([right_file.to_string_lossy()])
-        .mods(command_mod)
-        .build();
+#[derive(Debug, Builder)]
+#[builder(build_fn(error = "BuilderError"))]
+struct DiffContext<'a, 'b> {
+    left_dir: &'a Path,
+    right_dir: &'a Path,
+    #[builder(default, setter(into, strip_option))]
+    output_dir: Option<&'a Path>,
+    config: &'b config::Config,
+}
 
-    api::cmd(&new_tab_cmd, &cmd_opt)?;
-    api::command("set winfixbuf | set nomodifiable")?;
-    api::cmd(&diff_tab_cmd, &cmd_opt)?;
-    api::command("set winfixbuf | set modifiable")?;
-    Ok(())
+impl<'a, 'b> DiffContext<'a, 'b> {
+    fn open_tabs(&self) -> Result<(), DiffDirsError> {
+        if let Some(output_dir) = self.output_dir {
+            DIFF_DIRS.replace(DiffDirType::Three(
+                self.left_dir.to_owned(),
+                self.right_dir.to_owned(),
+                output_dir.to_owned(),
+            ));
+        } else {
+            DIFF_DIRS.replace(DiffDirType::Two(
+                self.left_dir.to_owned(),
+                self.right_dir.to_owned(),
+            ));
+        }
+        let files = make_file_set(self.left_dir, self.right_dir);
+
+        let first_tabpage = api::get_current_tabpage();
+        let mut is_first_cmd = true;
+        api::call_function::<_, usize>("setqflist", (Array::new(), 'r'))?;
+
+        let mut path_tab_map = BTreeMap::new();
+        for file in files {
+            let left_file = self.left_dir.join(&file);
+            let right_file = self.right_dir.join(&file);
+            let mut tab_builder = DiffTabBuilder::default();
+            tab_builder
+                .config(self.config)
+                .left_file(&left_file)
+                .right_file(&right_file);
+            let modifiable_file = if let Some(output_dir) = self.output_dir {
+                let output_file = output_dir.join(&file);
+                tab_builder.output_file(output_file.clone());
+                output_file
+            } else {
+                right_file.clone()
+            };
+            tab_builder.build()?.open(is_first_cmd)?;
+            let modifiable_buf = Buffer::current();
+            let mut qflist_entry = Dictionary::new();
+            qflist_entry.insert("bufnr", modifiable_buf.handle());
+            qflist_entry.insert("filename", modifiable_file.to_string_lossy());
+            qflist_entry.insert("text", file.to_string_lossy());
+            api::call_function::<_, usize>("setqflist", (Array::from_iter([qflist_entry]), 'a'))?;
+            is_first_cmd = false;
+            path_tab_map.insert(file, api::get_current_tabpage());
+        }
+        api::set_current_tabpage(&first_tabpage)?;
+        DIFF_FILES.replace(path_tab_map);
+        Ok(())
+    }
+}
+
+#[derive(Debug, Builder)]
+#[builder(build_fn(error = "BuilderError"))]
+struct DiffTab<'a, 'b> {
+    left_file: &'a Path,
+    right_file: &'a Path,
+    #[builder(default, setter(into, strip_option))]
+    output_file: Option<PathBuf>,
+    config: &'b config::Config,
+}
+
+impl<'a, 'b> DiffTab<'a, 'b> {
+    fn open(&self, is_first: bool) -> Result<(), DiffDirsError> {
+        let cmd_opt = CmdOpts::builder().output(false).build();
+        let new_tab_cmd_str = if is_first { "edit" } else { "tabedit" };
+        let new_tab_cmd = CmdInfos::builder()
+            .cmd(new_tab_cmd_str)
+            .args([self.left_file.to_string_lossy()])
+            .nextcmd("difft")
+            .build();
+        let mut command_mod = CommandModifiers::default();
+        command_mod.vertical = true;
+        let diff_win_cmd = CmdInfos::builder()
+            .cmd("diffs")
+            .args([self.right_file.to_string_lossy()])
+            .mods(command_mod)
+            .build();
+
+        api::cmd(&new_tab_cmd, &cmd_opt)?;
+        self.set_left_opt()?;
+
+        api::cmd(&diff_win_cmd, &cmd_opt)?;
+        if let Some(output) = &self.output_file {
+            self.set_left_opt()?;
+
+            let mut cmd_mod = CommandModifiers::default();
+            cmd_mod.split = Some(SplitModifier::BotRight);
+            let output_win_cmd = CmdInfos::builder()
+                .cmd("diffs")
+                .args([output.to_string_lossy()])
+                .mods(cmd_mod)
+                .build();
+            api::cmd(&output_win_cmd, &cmd_opt)?;
+        }
+        self.set_right_opt()?;
+        Ok(())
+    }
+
+    #[inline]
+    fn set_left_opt(&self) -> Result<(), DiffDirsError> {
+        api::command("set winfixbuf | set nomodifiable")?;
+        self.config.set_left_diff_opt(api::get_current_win())
+    }
+
+    #[inline]
+    fn set_right_opt(&self) -> Result<(), DiffDirsError> {
+        api::command("set winfixbuf | set modifiable")?;
+        self.config.set_right_diff_opt(api::get_current_win())
+    }
 }


### PR DESCRIPTION
if you run `DiffDirs` command with three arguments, it starts 3-pane diff mode. The first two arguments are used to spawn left-top and right-top panes respectively with nomodifiable. The last argument is used to spawn a bottom pane with modifiable options.

This commit also include supporting configuration of window options. The left_diff_opt is applied to the left pane and the right pane if it's in 3-pane diff mode. The right_diff_opt is applied to the right pane if it's in 2-pane diff mode or the bottom pane if it's in 3-pane diff mode.